### PR TITLE
Fix typo in ConnectionPortCheck script

### DIFF
--- a/ConnectionPortCheck.ps1
+++ b/ConnectionPortCheck.ps1
@@ -1,4 +1,4 @@
-﻿# Set the target computer (hostname or IP)
+# Set the target computer (hostname or IP)
 $computer = "TargetHostOrIP"
 
 # Define the port range
@@ -32,7 +32,7 @@ while ($true) {
         }
     }
 
-# If all ports are stabe and 5 min has elapsed, log a message
+# If all ports are stable and 5 min has elapsed, log a message
 if ($allPortsStable -and (($currentTime - $lastSummaryTime).TotalMinutes -ge 5)) {
     $timeStamp = $currentTime.ToString("yyyy-MM-dd HH:mm:ss")
     $summaryMessage = "$timeStamp - All ports on $computer are stable."


### PR DESCRIPTION
## Summary
- remove BOM from ConnectionPortCheck.ps1
- correct spelling of "stable" in summary log message

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685be484bf50832b934f33ce3b709639